### PR TITLE
PlatformIO Library Manager manifest file

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,10 @@
+{
+  "name": "SFE-Arduino-CC3000",
+  "keywords": "wifi, wi-fi, http, web, server, json, rest, spi",
+  "description": "Arduino library for the TI CC3000 WiFi Shield and SparkFun Breakout Board",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/sparkfun/SFE_CC3000_Library.git"
+  }
+}


### PR DESCRIPTION
- This library in Web: http://platformio.ikravets.com/#!/lib/show/61/SparkFun-CC3000
- Specification: [PlatformIO Library Manager](http://docs.platformio.ikravets.com/en/latest/librarymanager/index.html)
- Integration: [IDE Integration](http://docs.platformio.ikravets.com/en/latest/ide.html)

`library.json` is a library manifest file which can be used with different tools/managers to organise embedded libraries. Currently, only [PlatformIO](http://platformio.ikravets.com) uses it.  How does this look from CLI:

``` bash
$ platformio lib search “+arduino +cc300“
# Found ... libraries:
# SFE-Arduino-CC3000        Arduino library for the TI CC3000 WiFi Shield and SparkFun Breakout Board

$ platformio lib install SFE-Arduino-CC3000
# Installing SFE-Arduino-CC3000  library:
# Downloading  [####################################]  100%
# Unpacking  [####################################]  100%
# The library ‘SFE-Arduino-CC3000' has been successfully installed!

$ platformio lib show SFE-Arduino-CC3000
# SFE-Arduino-CC3000
# -------------
# Author: SparkFun Electronics
# Keywords: wifi, wi-fi, http, web, server, json, rest, spi
# Version: ***
#
# Arduino library for the TI CC3000 WiFi Shield and SparkFun Breakout Board

$ platformio lib update
# Updating SFE-Arduino-CC3000  library:
# Versions: Current=***, Latest=***       [Up-to-date]
```
